### PR TITLE
Fix stat scaling configuration usage

### DIFF
--- a/FPS-ECS-Unity/Assets/_Project/Develop/Code/Runtime/Gameplay/ProgressionFeature/Systems/ApplyUpgradesSystem.cs
+++ b/FPS-ECS-Unity/Assets/_Project/Develop/Code/Runtime/Gameplay/ProgressionFeature/Systems/ApplyUpgradesSystem.cs
@@ -59,8 +59,8 @@ namespace FpsEcs.Runtime.Gameplay.ProgressionFeature.Systems
             {
                 var upgrades = _applyUpgradesEventPool.Value.Get(eventEntity);
 
-                var healthBonus = upgrades.Health * GameConfig.DamageBonusPerUpgradeLevel;
-                var speedBonus = upgrades.Speed * GameConfig.DamageBonusPerUpgradeLevel;
+                var healthBonus = upgrades.Health * GameConfig.HealthBonusPerUpgradeLevel;
+                var speedBonus = upgrades.Speed * GameConfig.SpeedBonusPerUpgradeLevel;
                 var damageBonus = upgrades.Damage * GameConfig.DamageBonusPerUpgradeLevel;
                 
                 ApplyUpgradesToPlayer(healthBonus, speedBonus);


### PR DESCRIPTION
## Summary
- use health and speed upgrade configuration values when applying player bonuses
- keep damage upgrade scaling tied to the damage configuration value

## Testing
- not run (environment does not support Unity builds)

------
https://chatgpt.com/codex/tasks/task_e_68e10d3bfe3083248e239bca2ddce5e6